### PR TITLE
Allow for multiple gene:transcript pairs in CT

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,8 @@ Quick Usage
     -a, --autoSelect      Auto Select which transcript to be used[default]
     -c canonicalExons.txt, --canonicalTranscripts canonicalExons.txt
                             Location of canonical transcript list for each gene.
-                            This file is required now
+                            This file is required now.
+                            It is also edited to include an id column, id column will match new input requirement for RNA Fusions
     -p, --plotSV          Plot the structural variant in question (very primitive)
     -u uniprot.txt, --uniprotFile uniprot.txt
                             Location of UniProt list contain information for
@@ -73,6 +74,17 @@ as the header and where:
 * **chr2:** Its the chromosome name for second break point [1,2,3,4,5,6,7 etc..],
 * **pos2:** Its the chromosome loaction for second break point [1-based],
 * **str2:** Its the read direction for the second break point [0=top/plus/reference, 1=bottom/minus/complement], 
+* **id1:** Unique identifier for first breakpoint
+* **id2:** Unique identifier for second breakpoint
+
+Canonical transcripts file contains:
+
+gene    transcript      id
+
+as the header and where:
+* **gene:** Gene name for fusion id
+* **transcript:** Transcript for fusion id
+* **id:** Fusion id corresponding to id1 or id2 from input file
 
 Output file will is a tab-delimited file containing:
 

--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,7 @@ Canonical transcripts file contains:
 gene    transcript      id
 
 as the header and where:
+
 * **gene:** Gene name for fusion id
 * **transcript:** Transcript for fusion id
 * **id:** Fusion id corresponding to id1 or id2 from input file

--- a/iAnnotateSV/FindCanonicalTranscript.py
+++ b/iAnnotateSV/FindCanonicalTranscript.py
@@ -6,12 +6,14 @@ Created on  Mar 4, 2015
 from operator import itemgetter
 import logging
 import coloredlogs
+import helper as hp
 '''
 Get the mininmumIndex for a list and return the variables that match canonical transcript
 Preference:# zone: 1=exon, 2=intron, 3=3'-UTR, 4=5'-UTR, 5=promoter
 '''  
+
 coloredlogs.install(level='DEBUG')
-def FindCT(geneList,transcriptList,siteList,zoneList,strandList,intronnumList,intronframeList,ctDict):
+def FindCT(geneList,transcriptList,siteList,zoneList,strandList,intronnumList,intronframeList,ctDict,id):
     gene = None
     transcript = None
     site = None
@@ -26,20 +28,17 @@ def FindCT(geneList,transcriptList,siteList,zoneList,strandList,intronnumList,in
         minIndex = None
         for gene in geneList:
             #print gene
-            if gene in ctDict:
-                cts = ctDict.get(gene)
+            if ctDict['gene'].str.contains(gene).any():
+                result = ctDict.query(f'id == {id}')
+                cts = result['transcript'].values[0] if not result.empty else None
                 break
         if(cts):
-            if(len(cts) > 1 ):
-                minIndex = min(enumerate(zoneList), key=itemgetter(1))[0] 
-            else:
-                #print "CTS",cts[0]
-                try:
-                    #print "I am here", transcriptList.index(cts[0])
-                    minIndex = transcriptList.index(cts[0])
-                except ValueError:
-                    logging.warn("iAnnotateSV::FindCanonicalTranscript: The given canonical transcript does not cover the coordinates.")
-                    minIndex = min(enumerate(zoneList), key=itemgetter(1))[0]
+            try:
+                minIndex = transcriptList.index(cts)
+            except ValueError:
+                logging.warn("iAnnotateSV::FindCanonicalTranscript: The given canonical transcript does not cover the coordinates for id:")
+                logging.warn(id)
+                minIndex = min(enumerate(zoneList), key=itemgetter(1))[0]
         else:
             minIndex = min(enumerate(zoneList), key=itemgetter(1))[0] 
         #print minIndex

--- a/iAnnotateSV/FindCanonicalTranscript.py
+++ b/iAnnotateSV/FindCanonicalTranscript.py
@@ -6,12 +6,10 @@ Created on  Mar 4, 2015
 from operator import itemgetter
 import logging
 import coloredlogs
-import helper as hp
 '''
 Get the mininmumIndex for a list and return the variables that match canonical transcript
 Preference:# zone: 1=exon, 2=intron, 3=3'-UTR, 4=5'-UTR, 5=promoter
 '''  
-
 coloredlogs.install(level='DEBUG')
 def FindCT(geneList,transcriptList,siteList,zoneList,strandList,intronnumList,intronframeList,ctDict,id):
     gene = None

--- a/iAnnotateSV/iAnnotateSV.py
+++ b/iAnnotateSV/iAnnotateSV.py
@@ -189,7 +189,7 @@ def processSV(svDF, refDF, args):
         logging.info("iAnnotateSV: Processing Each Structural Variants...")
     # Read Canonical Transcript if the file is given in the cmdline
     if(args.canonicalTranscripts):
-        ctDict = hp.ReadTranscriptFile(args.canonicalTranscripts)
+        ctDict = pd.read_csv(args.canonicalTranscripts, sep='\t', header=0)
     annDF = pd.DataFrame(
         columns=[
             'chr1',
@@ -213,6 +213,8 @@ def processSV(svDF, refDF, args):
         pos2 = int(row.loc['pos2'])
         str1 = int(row.loc['str1'])
         str2 = int(row.loc['str2'])
+        id1 = str(row.loc['id1'])
+        id2 = str(row.loc['id2'])
         b1, b2 = (None,)*2
         if(args.autoSelect):
             (gene1, transcript1, site1, zone1, strand1, intronnum1,
@@ -234,13 +236,13 @@ def processSV(svDF, refDF, args):
         else:
             try:
                 (gene1List, transcript1List, site1List, zone1List, strand1List, intronnum1List, intronframe1List) = aeb.AnnotateEachBreakpoint(chr1, pos1, str1, refDF, args.autoSelect)
-                (gene1, transcript1, site1, zone1, strand1, intronnum1, intronframe1) = fct.FindCT(gene1List, transcript1List, site1List, zone1List, strand1List, intronnum1List, intronframe1List, ctDict)
+                (gene1, transcript1, site1, zone1, strand1, intronnum1, intronframe1) = fct.FindCT(gene1List, transcript1List, site1List, zone1List, strand1List, intronnum1List, intronframe1List, ctDict, id1)
             except (IntergenicError, ChrError) as b1:
                 logging.info("iAnnotateSV: " + str(b1))
                 (gene1, transcript1, site1, zone1, strand1, intronnum1, intronframe1) = ("-",)*7
             try:
                 (gene2List, transcript2List, site2List, zone2List, strand2List, intronnum2List, intronframe2List) = aeb.AnnotateEachBreakpoint(chr2, pos2, str2, refDF, args.autoSelect)
-                (gene2, transcript2, site2, zone2, strand2, intronnum2, intronframe2) = fct.FindCT(gene2List, transcript2List, site2List, zone2List, strand2List, intronnum2List, intronframe2List, ctDict)
+                (gene2, transcript2, site2, zone2, strand2, intronnum2, intronframe2) = fct.FindCT(gene2List, transcript2List, site2List, zone2List, strand2List, intronnum2List, intronframe2List, ctDict, id2)
             except (IntergenicError, ChrError) as b2:
                 logging.info("iAnnotateSV: " + str(b2))
                 (gene2, transcript2, site2, zone2, strand2, intronnum2, intronframe2) = ("-",)*7


### PR DESCRIPTION
FORTE outputs specific transcripts per fusion, and sometimes a sample can have multiple different transcripts for different fusions. This code modifies source code to take in "id" variable per fusion and map that to the desired transcript 

- [x] Modify code to function with multiple transcripts
- [x] Add to readme how canonicaltranscripts and input needs to be formatted for this branch